### PR TITLE
Improve send reliability and update radio IP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Meshquake monitors real-time earthquakes from the USGS feed and sends formatted alerts over Meshtastic mesh radio networks. It's a single-file Python application (`meshquake.py`, ~300 lines) designed for unattended Docker deployment on Raspberry Pi.
+
+## Build & Run Commands
+
+```bash
+# Build and run
+docker-compose build
+docker-compose up -d
+
+# View logs
+docker logs -f meshquake-meshquake-1
+
+# Reset state (clear DB and logs)
+rm -f data/earthquakes.db data/meshquake_error.log
+
+# Verify cron is running
+docker exec meshquake-meshquake-1 crontab -l
+
+# Manually trigger test message
+docker exec meshquake-meshquake-1 /app/send_test_message.sh
+```
+
+There are no unit tests, linters, or formatters configured.
+
+## Architecture
+
+**Single-file app** — all logic lives in `meshquake.py`. No packages, no modules.
+
+### Runtime Modes (first CLI arg)
+- `dev` — dry run, no message sending, uses `processed_quakes_dev` table
+- `devsend` — sends to radio but uses dev table
+- `prod` — continuous 60-second polling loop, sends alerts, uses `processed_quakes` table
+
+### Data Flow
+1. `parse_args()` → manual `sys.argv` parsing (no argparse)
+2. `lookup_zip()` → resolves ZIP to lat/lon/city via zippopotam.us API
+3. `fetch_earthquake_data()` → polls USGS GeoJSON feed (all quakes, last hour)
+4. `process_earthquakes()` → filters by Haversine distance and magnitude, formats message, sends via Meshtastic CLI
+5. Only processes **one quake per polling cycle** (returns after first match)
+
+### Meshtastic Integration
+Messages are sent by shelling out to the `meshtastic` CLI tool via `subprocess.run()`. Messages >200 bytes are chunked into 3 parts with 4-second delays between sends.
+
+### Persistence
+- SQLite database (`data/earthquakes.db`) tracks processed quake IDs to prevent duplicate alerts
+- Error log at `data/meshquake_error.log`
+- Both persist outside the container via volume mount (`./data:/app/data`)
+
+### Container Setup
+- **Dockerfile**: miniconda3 base → conda env from `environment.yml` → cron + tzdata installed
+- **entrypoint.sh**: installs cron job (12-hour test messages), starts cron daemon, then `exec`s the Python app as PID 1
+- **send_test_message.sh**: cron-triggered script that sends a test message via meshtastic CLI
+- `RADIO_IP` and `CH_INDEX` env vars in docker-compose.yml must match the `command:` flags (env vars are used by cron, flags by the Python app)
+
+### Key Globals
+- `LOCATION_LABEL` — mutable global, set from ZIP lookup, hardcoded abbreviation for "Mountain View" → "Mt View"
+- `TABLE_NAME` — mutable global, switches between prod/dev SQLite tables
+
+## Dependencies (environment.yml)
+
+Python 3.10 via conda: `requests`, `pytz`, `meshtastic` (pip). No dev dependencies.

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Example:
 ```yaml
 environment:
   - DATA_DIR=/app/data
-  - RADIO_IP=192.168.69.8
+  - RADIO_IP=192.168.69.7
   - CH_INDEX=2
 command: >
   prod --zip 95014 --min-mag 1.0 --max-distance 100
-  --radio-ip 192.168.69.8 --ch-index 2
+  --radio-ip 192.168.69.7 --ch-index 2
 ```
 
 The `RADIO_IP` and `CH_INDEX` environment variables are used by the cron-based test message (see below). Make sure they match the values in `command`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     working_dir: /app
     environment:
       - DATA_DIR=/app/data
-      - RADIO_IP=192.168.69.8
+      - RADIO_IP=192.168.69.7
       - CH_INDEX=2
     command: >
-      prod --zip 94040 --min-mag 2.5 --max-distance 300
-      --radio-ip 192.168.69.8 --ch-index 2
+      prod --zip 94040 --min-mag 3.0 --max-distance 300
+      --radio-ip 192.168.69.7 --ch-index 2
     restart: unless-stopped

--- a/meshquake.py
+++ b/meshquake.py
@@ -123,17 +123,26 @@ def fetch_earthquake_data():
 
 # --------------------- CLI Message Send ---------------------
 
+SEND_TIMEOUT_SECONDS = 60
+
 def send_meshtastic_message(text, target_ip=None, channel=0):
+    """Send one text message via the meshtastic CLI. Returns True on success, False otherwise."""
     cmd = ["meshtastic"]
     if target_ip:
         cmd.extend(["-t", target_ip])
     cmd.extend(["--ch-index", str(channel), "--sendtext", text])
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, timeout=SEND_TIMEOUT_SECONDS)
         logging.info(f"Sent message (ch {channel}): {text}")
+        return True
     except subprocess.CalledProcessError as e:
         logging.error(f"Meshtastic send failed: {e}")
         logging.error(f"Failed message: {text}")
+        return False
+    except subprocess.TimeoutExpired as e:
+        logging.error(f"Meshtastic send timed out after {SEND_TIMEOUT_SECONDS}s: {e}")
+        logging.error(f"Failed message: {text}")
+        return False
 
 # --------------------- Main Processing ---------------------
 
@@ -158,31 +167,37 @@ def process_earthquakes(data, mode="prod", radio_ip=None, min_mag=0.0, channel=0
         if not is_within_radius(lat, lon, center_lat, center_lon, radius=max_distance):
             continue
 
-        magnitude = properties.get("mag", 0)
+        # USGS may report a null magnitude; .get's default only covers missing keys,
+        # so coerce None to 0 to avoid a TypeError on the comparison below.
+        magnitude = properties.get("mag")
+        if magnitude is None:
+            magnitude = 0
         if magnitude < min_mag:
             continue
 
         place = properties.get("place", "Unknown location")
         time_epoch = properties.get("time", 0) / 1000
-        short_date = datetime.fromtimestamp(time_epoch, pytz.timezone("America/Los_Angeles")).strftime("%m-%d %H:%M")
+        local_dt = datetime.fromtimestamp(time_epoch, pytz.timezone("America/Los_Angeles"))
+        short_date = local_dt.strftime("%m-%d %H:%M")
+        tz_abbr = local_dt.strftime("%Z")  # PDT or PST depending on the date
         distance = haversine(lat, lon, center_lat, center_lon)
 
         # Format with emojis and multi-line
-        full_message = f"🌎 Earthquake Alert!\n📍 M{magnitude:.1f} | {distance:.0f}mi from {LOCATION_LABEL}\n🗺️ {place}\n⏰ {short_date} PDT"
+        full_message = f"🌎 Earthquake Alert!\n📍 M{magnitude:.1f} | {distance:.0f}mi from {LOCATION_LABEL}\n🗺️ {place}\n⏰ {short_date} {tz_abbr}"
         message_bytes = len(full_message.encode("utf-8"))
-        
+
         # Prepare parts for chunking if needed
         part1 = f"🌎 Earthquake Alert!\n📍 M{magnitude:.1f} | {distance:.0f}mi from {LOCATION_LABEL}"
         part2 = f"🗺️ {place}"
-        part3 = f"⏰ {short_date} PDT"
+        part3 = f"⏰ {short_date} {tz_abbr}"
 
         logging.info(f"Matched quake: {quake_id} -> {full_message}")
-        mark_quake_processed(quake_id, full_message, int(time_epoch))
 
         if mode == "dev":
             print("[DEV MODE]")
             print("Most recent matching message (not sent):")
             print(full_message)
+            mark_quake_processed(quake_id, full_message, int(time_epoch))
             print("\nAll simulated stored messages (dev table):\n")
             rows = fetch_all_messages()
             for r in rows:
@@ -191,15 +206,24 @@ def process_earthquakes(data, mode="prod", radio_ip=None, min_mag=0.0, channel=0
             return
 
         if message_bytes <= 200:
-            send_meshtastic_message(full_message, target_ip=radio_ip, channel=channel)
+            sent = send_meshtastic_message(full_message, target_ip=radio_ip, channel=channel)
         else:
-            send_meshtastic_message(part1, target_ip=radio_ip, channel=channel)
-            time.sleep(4)
-            send_meshtastic_message(part2, target_ip=radio_ip, channel=channel)
-            time.sleep(4)
-            send_meshtastic_message(part3, target_ip=radio_ip, channel=channel)
+            sent = send_meshtastic_message(part1, target_ip=radio_ip, channel=channel)
+            if sent:
+                time.sleep(4)
+                send_meshtastic_message(part2, target_ip=radio_ip, channel=channel)
+                time.sleep(4)
+                send_meshtastic_message(part3, target_ip=radio_ip, channel=channel)
 
-        return  # Send/store one quake per run
+        # Only record the quake as processed once it was actually delivered, so a failed
+        # send (e.g. unreachable radio) is retried on the next polling cycle instead of
+        # being silently lost.
+        if sent:
+            mark_quake_processed(quake_id, full_message, int(time_epoch))
+        else:
+            logging.warning(f"Send failed for {quake_id}; will retry next cycle (not marked processed)")
+
+        return  # Process one quake per run
 
 # --------------------- Argument Parser ---------------------
 

--- a/send_test_message.sh
+++ b/send_test_message.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-conda run -n meshquake meshtastic --host "${RADIO_IP}" --ch-index "${CH_INDEX}" --sendtext "Meshquake Test - https://bayme.sh/ Discord for any questions" >> /app/data/meshquake_error.log 2>&1
+# Invoked by cron, which runs with a minimal PATH that does NOT include conda.
+# Call the meshtastic binary from the conda env by absolute path instead of `conda run`.
+MESHTASTIC=/opt/conda/envs/meshquake/bin/meshtastic
+"${MESHTASTIC}" --host "${RADIO_IP}" --ch-index "${CH_INDEX}" --sendtext "Meshquake Test - https://bayme.sh/ Discord for any questions" >> /app/data/meshquake_error.log 2>&1


### PR DESCRIPTION
Make Meshtastic delivery robust against an unreachable or slow radio:

- send_meshtastic_message() now returns success/failure and enforces a 60s timeout, catching both CalledProcessError and TimeoutExpired.
- Quakes are marked processed only after a successful send, so a failed send is retried on the next polling cycle instead of being silently lost.
- Coerce a null USGS magnitude to 0 to avoid a TypeError on the filter.
- send_test_message.sh calls the meshtastic binary by absolute path instead of `conda run`, fixing silent cron failures (cron's minimal PATH lacks conda).
- Point config at the radio's new IP (192.168.69.8 -> 192.168.69.7).
- Add CLAUDE.md project guide.

Verified end-to-end against the live radio: init message and cron test message both deliver; retry-on-failure logic confirmed via a harness.