### PR TITLE
Rename test message to heartbeat and send once daily at noon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,8 @@ Messages are sent by shelling out to the `meshtastic` CLI tool via `subprocess.r
 
 ### Container Setup
 - **Dockerfile**: miniconda3 base → conda env from `environment.yml` → cron + tzdata installed
-- **entrypoint.sh**: installs cron job (12-hour test messages), starts cron daemon, then `exec`s the Python app as PID 1
-- **send_test_message.sh**: cron-triggered script that sends a test message via meshtastic CLI
+- **entrypoint.sh**: installs cron job (daily heartbeat message at noon), starts cron daemon, then `exec`s the Python app as PID 1
+- **send_test_message.sh**: cron-triggered script that sends a heartbeat message via meshtastic CLI
 - `RADIO_IP` and `CH_INDEX` env vars in docker-compose.yml must match the `command:` flags (env vars are used by cron, flags by the Python app)
 
 ### Key Globals

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Long messages (>200 bytes) are automatically chunked into separate messages:
 
 ---
 
-## 📡 Periodic Test Message
+## 📡 Periodic Heartbeat Message
 
-A cron job inside the container sends a test message over Meshtastic every 12 hours (midnight and noon). This helps confirm the radio link is alive even when no earthquakes are occurring.
+A cron job inside the container sends a heartbeat message over Meshtastic once a day at noon. This helps confirm the radio link is alive even when no earthquakes are occurring.
 
-The message: `Meshquake Test - https://bayme.sh/ Discord for any questions`
+The message: `Meshquake Heartbeat - https://bayme.sh/ Discord for any questions`
 
 To verify cron is running:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Write crontab with env vars baked in
-echo "0 */12 * * * RADIO_IP=${RADIO_IP} CH_INDEX=${CH_INDEX} /app/send_test_message.sh" | crontab -
+echo "0 12 * * * RADIO_IP=${RADIO_IP} CH_INDEX=${CH_INDEX} /app/send_test_message.sh" | crontab -
 
 # Start cron in the background
 cron

--- a/send_test_message.sh
+++ b/send_test_message.sh
@@ -2,4 +2,4 @@
 # Invoked by cron, which runs with a minimal PATH that does NOT include conda.
 # Call the meshtastic binary from the conda env by absolute path instead of `conda run`.
 MESHTASTIC=/opt/conda/envs/meshquake/bin/meshtastic
-"${MESHTASTIC}" --host "${RADIO_IP}" --ch-index "${CH_INDEX}" --sendtext "Meshquake Test - https://bayme.sh/ Discord for any questions" >> /app/data/meshquake_error.log 2>&1
+"${MESHTASTIC}" --host "${RADIO_IP}" --ch-index "${CH_INDEX}" --sendtext "Meshquake Heartbeat - https://bayme.sh/ Discord for any questions" >> /app/data/meshquake_error.log 2>&1


### PR DESCRIPTION
## Summary
- Rename the periodic radio-link check message from "Meshquake Test" to "Meshquake Heartbeat"
- Change the cron schedule from every 12 hours (`0 */12 * * *`) to once daily at noon (`0 12 * * *`, container TZ is America/Los_Angeles)
- Update README.md and CLAUDE.md to match

## Notes
Both scripts are baked into the image, so a `docker-compose build && docker-compose up -d` is required after merging for the change to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)